### PR TITLE
Add CLI output, rework documentation interfacing

### DIFF
--- a/Classes/Backend/Controller/AdminModuleController.php
+++ b/Classes/Backend/Controller/AdminModuleController.php
@@ -17,19 +17,15 @@ declare(strict_types=1);
 
 namespace Cru\Psr14EventList\Backend\Controller;
 
-use TYPO3\CMS\Core\Imaging\Icon;
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Backend\Template\ModuleTemplate;
 use TYPO3\CMS\Core\Localization\LanguageService;
-use TYPO3\CMS\Backend\Template\Components\ButtonBar;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use Cru\Psr14EventList\Service\ProvideEventListService;
-use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 #[AsController]
 final class AdminModuleController

--- a/Classes/Backend/Controller/AdminModuleController.php
+++ b/Classes/Backend/Controller/AdminModuleController.php
@@ -2,8 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Cru\Psr14EventList\Backend\Controller;
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
 
+namespace Cru\Psr14EventList\Backend\Controller;
 
 use TYPO3\CMS\Core\Imaging\Icon;
 use Psr\Http\Message\ResponseInterface;

--- a/Classes/Command/EventListCommand.php
+++ b/Classes/Command/EventListCommand.php
@@ -65,6 +65,13 @@ final class EventListCommand extends Command
                 null,
             )
             ->addOption(
+                'show-missing',
+                '',
+                InputOption::VALUE_NONE,
+                'List all PSR-14 with missing documentation',
+                null,
+            )
+            ->addOption(
                 'vertical-table',
                 '',
                 InputOption::VALUE_NONE,
@@ -145,6 +152,13 @@ final class EventListCommand extends Command
 
         if (count($errors) > 0) {
             $finalStats[] = '<error>' . count($errors) . '</error> missing doc links.';
+            if ($input->getOption('show-missing') === true) {
+                $output->writeln('');
+                $output->writeln('<info>Missing doc links:</info>');
+                foreach ($errors as $missingEvent => $_) {
+                    $output->writeln('- ' . $missingEvent);
+                }
+            }
         }
 
         $output->writeln('');

--- a/Classes/Command/EventListCommand.php
+++ b/Classes/Command/EventListCommand.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Cru\Psr14EventList\Command;
+
+use Cru\Psr14EventList\Service\ProvideEventListService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class EventListCommand extends Command
+{
+    public function __construct(
+        private ProvideEventListService $provideEventListService
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setHelp('Shows available PSR-14 Events')
+            ->addOption(
+                'no-cache',
+                '',
+                InputOption::VALUE_NONE,
+                'Disable caching (lower performance, up-to-date results)',
+                null,
+            )
+            ->addOption(
+                'no-docs',
+                '',
+                InputOption::VALUE_NONE,
+                'Disable fetching Documentation link (faster performance)',
+                null,
+            )
+            ->addOption(
+                'no-table-separator',
+                '',
+                InputOption::VALUE_NONE,
+                'Prevent a table separator',
+                null,
+            )
+            ->addOption(
+                'no-table',
+                '',
+                InputOption::VALUE_NONE,
+                'Do not use table output, plaintext',
+                null,
+            )
+            ->addOption(
+                'vertical-table',
+                '',
+                InputOption::VALUE_NONE,
+                'Use a vertical table',
+                null,
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $finalStats = [];
+        $useCache = ($input->getOption('no-cache') !== true);
+        if ($useCache) {
+            $finalStats[] = 'Cached';
+            $output->writeln('<info>PSR-14 event list (cached)</info>');
+        } else {
+            $finalStats[] = 'Live';
+            $output->writeln('<info>PSR-14 event list (live)</info>');
+        }
+
+        $fetchDocs = ($input->getOption('no-docs') !== true);
+        if ($fetchDocs) {
+            $output->writeln('<info>Utilizing documentation links</info>');
+        } else {
+            $finalStats[] = 'Skipped docs';
+            $output->writeln('<info>Skipping documentation links</info>');
+        }
+
+        $eventList = $this->provideEventListService->getConfiguration($useCache, $fetchDocs, $output);
+
+        $output->writeln('Got <info>' . count($eventList) . '</info> events.');
+
+        if ($input->getOption('no-table') === true) {
+            $table = null;
+        } else {
+            $table = new Table($output);
+            if ($input->getOption('vertical-table') === true) {
+                $table->setVertical();
+            }
+            $cols = ['Package' => 'package', 'EventClass' => 'label'];
+            if ($fetchDocs) {
+                $cols['Documentation'] = 'documentation';
+            }
+            $table->setHeaders(array_keys($cols));
+        }
+
+        $last = null;
+        $errors = [];
+        foreach ($eventList as $event) {
+            if ($last === null) {
+                $last = $event['package'];
+            }
+
+            if ($table === null) {
+                $output->writeln('<info>' . $event['label'] . '</info>');
+                if ($fetchDocs) {
+                    if ($event['documentation'] === '#none-found') {
+                        $output->writeln(' -> <error>N/A</error>');
+                        $errors[$event['label']] = true;
+                    } else {
+                        $output->writeln(' -> ' . $event['documentation']);
+                    }
+                }
+            } else {
+                if ($last !== $event['package'] && $input->getOption('no-table-separator') !== true) {
+                    $table?->addRow(new TableSeparator());
+                }
+                $row = [];
+                foreach ($cols as $rowColumn) {
+                    $row[] = $event[$rowColumn] ?? 'N/A';
+                }
+                $table->addRow($row);
+            }
+            $last = $event['package'];
+        }
+
+        $table?->render();
+
+        if (count($errors) > 0) {
+            $finalStats[] = '<error>' . count($errors) . '</error> missing doc links.';
+        }
+
+        $output->writeln('');
+        $output->writeln('<info>Total:</info> ' . count($eventList) . ' events. ' . implode(', ', $finalStats));
+
+
+        return Command::SUCCESS;
+    }
+}

--- a/Classes/Service/ProvideEventListService.php
+++ b/Classes/Service/ProvideEventListService.php
@@ -17,67 +17,119 @@ declare(strict_types=1);
 
 namespace Cru\Psr14EventList\Service;
 
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Package\PackageManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class ProvideEventListService
+final readonly class ProvideEventListService
 {
-    public function __construct() {}
+    public function __construct(
+        private PackageManager $packageManager,
+        private Typo3Version $typo3Version,
+    ) {
+    }
 
-    public function getConfiguration(): array
+    public function getConfiguration(bool $useCache = true, bool $fetchDocs = true, ?OutputInterface $cliOutput = null): array
     {
-        $packageManager = GeneralUtility::makeInstance(PackageManager::class);
         $eventClasses = [];
+        $docsUrl = 'https://docs.typo3.org/m/typo3/reference-coreapi/' .  $this->typo3Version->getBranch() . '/en-us/';
+        $docsUrlFallback = 'https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/';
 
-        foreach ($packageManager->getActivePackages() as $package) {
+        if ($fetchDocs) {
+            if ($cliOutput?->isVerbose()) {
+                $cliOutput->writeln('Using <info>' . $docsUrl . '</info> for doc lookup.');
+            }
+            $cacheFile = Environment::getVarPath() . '/cache/data/events_docs.json';
+
+            // Do a live access if either caching is disabled, or the cachefile is missing or oudated.
+            $docsCache = [];
+            if ($useCache === true
+                && file_exists($cacheFile)
+                && filemtime($cacheFile) < time()-86400
+            ) {
+                $docsCache = json_decode(file_get_contents($cacheFile), true);
+                if ($cliOutput?->isVerbose()) {
+                    $cliOutput->writeln('Retrieved <info>' . count($docsCache) . ' doc-links</info> from cache</info>');
+                }
+            } else {
+                $jsonContents = GeneralUtility::getUrl($docsUrl . 'objects.inv.json');
+
+                if ($jsonContents === false || $jsonContents === '') {
+                    // Requesting versions like '14.1', '15.0' may lead to missing link.
+                    // Use "main" as a fallback for the most recent version then.
+                    $jsonContents = GeneralUtility::getUrl($docsUrlFallback . 'objects.inv.json');
+                    if ($cliOutput?->isVerbose()) {
+                        $cliOutput->writeln('Using fallback <info>' . $docsUrlFallback . '</info> for doc lookup.');
+                    }
+                }
+
+                if ($jsonContents !== false && $jsonContents !== '') {
+                    $docuJson = json_decode($jsonContents, true);
+                    $docsCache = $docuJson['php:class'] ?? [];
+                    GeneralUtility::writeFileToTypo3tempDir($cacheFile, json_encode($docsCache));
+                    if ($cliOutput?->isVerbose()) {
+                        $cliOutput->writeln('Persisted <info>' . count($docsCache) . ' doc-links</info> to cache');
+                    }
+                } elseif ($cliOutput?->isVerbose()) {
+                    $cliOutput->writeln('<error>Could not write docs cache or invalid URL return.</error>');
+                }
+            }
+        }
+
+        $index = 0;
+        foreach ($this->packageManager->getActivePackages() as $package) {
+            $index++;
+            if ($cliOutput?->isVerbose()) {
+                $cliOutput->writeln('<info>#' . $index . '</info> Scanning <info>EXT:' . $package->getPackageKey() . '</info>');
+            }
+
             $classesPath = $package->getPackagePath() . 'Classes/';
             if (is_dir($classesPath)) {
-                $finder = new \Symfony\Component\Finder\Finder();
+                $finder = new Finder();
                 $finder->files()->in($classesPath)->name('*Event.php');
 
                 foreach ($finder as $file) {
+                    if ($cliOutput?->isVerbose()) {
+                        $cliOutput->writeln(' - <info>EXT:' . $file . '</info>');
+                    }
                     $content = file_get_contents($file->getRealPath());
 
                     if (preg_match('/namespace\s+([^;]+);/', $content, $matches)) {
                         $namespace = $matches[1];
                         $className = $namespace . '\\' . $file->getBasename('.php');
-                        $classNameDoc = str_replace('\\', '/', $className);
-                        $classNameDoc = str_replace('TYPO3/CMS/', '', $classNameDoc);
-                        $classNameDoc = str_replace('/Event/', '/', $classNameDoc);
+                        $classNameDoc = strtolower(str_replace('\\', '-', ltrim($className, '\\')));
 
                         if (class_exists($className) && !str_contains($className, 'Abstract')) {
                             $eventClasses[$className] = [
                                 'label' => $className,
                                 'package' => $package->getPackageKey(),
+                                'documentation' => '',
                             ];
 
-                            $cacheFile = Environment::getVarPath() . '/cache/data/events_docs.json';
-                            $docsCache = [];
-                            if (file_exists($cacheFile)) {
-                                $docsCache = json_decode(file_get_contents($cacheFile), true) ?? [];
+                            if (!$fetchDocs) {
+                                $eventClasses[$className]['documentation'] = '#skipped';
+                                continue;
                             }
 
-                            $cacheKey = md5($classNameDoc);
-                            if (!isset($docsCache[$cacheKey]) || $docsCache[$cacheKey]['expires'] < time()) {
-                                $docUrl = 'https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/ApiOverview/Events/Events/' . $classNameDoc . '.html';
-                                $headers = get_headers($docUrl, true);
-                                $exists = $headers && str_contains($headers[0], '200');
-
-                                $docsCache[$cacheKey] = [
-                                    'url' => $exists ? $docUrl : '',
-                                    'expires' => time() + 86400,
-                                ];
-
-                                GeneralUtility::writeFileToTypo3tempDir($cacheFile, json_encode($docsCache));
-                            }
-
-                            if ($docsCache[$cacheKey]['url'] !== '') {
-                                $eventClasses[$className]['documentation'] = $docsCache[$cacheKey]['url'];
+                            $eventClasses[$className]['documentation'] = '#none-found';
+                            if (isset($docsCache[$classNameDoc][2])) {
+                                $eventClasses[$className]['documentation'] = $docsUrl . $docsCache[$classNameDoc][2];
+                                if ($cliOutput?->isVeryVerbose()) {
+                                    $cliOutput->writeln('    - <info>Found <info>' . $classNameDoc . '</info> in docs php:class cache</info>');
+                                }
+                            } elseif ($cliOutput?->isVeryVerbose()) {
+                                $cliOutput->writeln('    - <info>Did not find <info>' . $classNameDoc . '</info> in docs php:class cache</info>');
                             }
                         }
                     }
                 }
+            }
+
+            if ($cliOutput?->isVerbose()) {
+                $cliOutput->writeln('');
             }
         }
 

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -1,9 +1,6 @@
 <?php
 
-
-
 use Cru\Psr14EventList\Backend\Controller\AdminModuleController;
-
 
 return [
     'web_examples' => [

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,5 +6,10 @@ services:
   Cru\Psr14EventList\:
     resource: '../Classes/*'
     exclude: '../Classes/Domain/Model/*'
-    
+  Cru\Psr14EventList\Command\EventListCommand:
+    tags:
+      - name: console.command
+        command: 'cru:list-psr14-events'
+        description: 'Shows available PSR-14 Events'
+
   

--- a/Resources/Private/Language/Module/de.locallang_mod.xlf
+++ b/Resources/Private/Language/Module/de.locallang_mod.xlf
@@ -1,41 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" target-language="de"  original="EXT:psr14_event_list/Resources/Private/Language/AdminModule/de.locallang_mod.xlf" datatype="plaintext" product-name="examples" date="2022-10-20T18:44:02+02:00">
+	<file source-language="en" target-language="de"  original="EXT:psr14_event_list/Resources/Private/Language/Module/de.locallang_mod.xlf" datatype="plaintext" product-name="examples" date="2022-10-20T18:44:02+02:00">
 		<header/>
 		<body>
 			<trans-unit id="overview_title">
-                <source>Übersicht der Core PSR-14 Events in TYPO3</source>
-                <target>Overview of Core PSR-14 Events in TYPO3</target>
+                <target>Übersicht der TYPO3 Core PSR-14 Events</target>
+                <source>Overview of TYPO3 Core PSR-14 Events</source>
             </trans-unit>
 
             <trans-unit id="overview_intro">
-                <source>Dieses Backend-Modul bietet eine detaillierte Übersicht über alle verfügbaren Core PSR-14-Events in TYPO3. PSR-14 ist eine Standardisierung für Event-Dispatching und bietet eine flexible Möglichkeit, die Logik innerhalb von TYPO3 zu erweitern, ohne den Core-Code zu verändern. In TYPO3 wird PSR-14 verwendet, um Ereignisse zu veröffentlichen, auf die Erweiterungen und benutzerdefinierte Logik reagieren können.</source>
-                <target>This backend module provides a detailed overview of all available core PSR-14 events in TYPO3. PSR-14 is a standardization for event dispatching and offers a flexible way to extend the logic within TYPO3 without modifying core code. In TYPO3, PSR-14 is used to publish events that extensions and custom logic can react to.</target>
+                <target>Dieses Backend-Modul bietet eine detailierte Übersicht über alle verfügbaren Core PSR-14-Events in TYPO3. PSR-14 ist eine Standardisierung für Event-Dispatching und bietet eine flexible Möglichkeit, die Logik innerhalb von TYPO3 zu erweitern, ohne den Core-Code zu verändern. In TYPO3 wird PSR-14 verwendet, um Ereignisse zu veröffentlichen, auf die Erweiterungen und benutzerdefinierte Logik reagieren können.</target>
+                <source>This backend module provides a detailed overview of all available core PSR-14 events in TYPO3. PSR-14 is a standardization for event dispatching and offers a flexible way to extend the logic within TYPO3 without modifying core code. In TYPO3, PSR-14 is used to publish events that extensions and custom logic can react to.</source>
             </trans-unit>
 
             <trans-unit id="overview_details">
-                <source>In dieser Übersicht findest du eine vollständige Liste aller Core-Events, die in TYPO3 ausgelöst werden, sowie zugehörige Informationen und Dokumentationen zu den jeweiligen Events. Jedes Event wird mit Links zur offiziellen TYPO3-Dokumentation versehen, sodass du mehr über das Event und seine Verwendung erfahren kannst.</source>
-                <target>This overview provides a complete list of all core events triggered in TYPO3, along with related information and documentation for each event. Each event is linked to the official TYPO3 documentation, so you can learn more about the event and how to use it.</target>
+                <target>In dieser Übersicht findest du eine vollständige Liste aller Core-Events, die in TYPO3 ausgelöst werden, sowie zugehörige Informationen und Dokumentations-Verweise zu den jeweiligen Events. Jedes Event wird mit Links zur offiziellen TYPO3-Dokumentation versehen, sodass du mehr über das Event und seine Verwendung erfahren kannst.</target>
+                <source>This overview provides a complete list of all core events triggered in TYPO3, along with related information and documentation for each event. Each event is linked to the official TYPO3 documentation, so you can learn more about the event and how to use it.</source>
             </trans-unit>
 
             <trans-unit id="documentation_text">
-                <source>Für eine ausführliche Erklärung zu PSR-14 und den Core-Events in TYPO3, kannst du die offizielle Übersicht der Core-Events in der TYPO3-Dokumentation besuchen. Dort findest du eine detaillierte Beschreibung der verschiedenen Events und Beispiele, wie du mit ihnen arbeiten kannst.</source>
-                <target>For an in-depth explanation of PSR-14 and the core events in TYPO3, you can visit the official overview of core events in the TYPO3 documentation. There you will find a detailed description of the various events and examples of how to work with them.</target>
+                <target>Für eine ausführliche Erklärung zu PSR-14 und den Core-Events in TYPO3, kannst du die offizielle Übersicht der Core-Events in der TYPO3-Dokumentation besuchen. Dort findest du eine detaillierte Beschreibung der verschiedenen Events und Beispiele, wie du mit ihnen arbeiten kannst.</target>
+                <source>For an in-depth explanation of PSR-14 and the core events in TYPO3, you can visit the official overview of core events in the TYPO3 documentation. There you will find a detailed description of the various events and examples of how to work with them.</source>
             </trans-unit>
 
             <trans-unit id="show_events">
-                <source>Um die Liste anzuzeigen, wechsle zum Listen-View im Dropdown</source>
-                <target>to show the list switch the dropdown to the list view</target>
+                <target>Um die Liste anzuzeigen, wechsele im Menü-Dropdown zu "Liste".</target>
+                <source>To show the list, switch the action menu dropdown to "List".</source>
             </trans-unit>
 
             <trans-unit id="documentation_link">
-                <source>TYPO3 Dokumentation</source>
-                <target>TYPO3 documentation</target>
+                <target>TYPO3 Dokumentation</target>
+                <source>TYPO3 documentation</source>
             </trans-unit>
 
             <trans-unit id="loading_warning">
-                <source>Warnung: Der erste Ladevorgang der Liste kann eine Weile dauern!</source>
-                <target>Warning the first load of the list may take a while!</target>
+                <target>Warnung: Der erste Ladevorgang der Liste kann eine Weile dauern!</target>
+                <source>Warning: First load of the list may take a while!</source>
             </trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/Module/locallang_mod.xlf
+++ b/Resources/Private/Language/Module/locallang_mod.xlf
@@ -3,17 +3,8 @@
 	<file source-language="en" original="EXT:psr14_event_list/Resources/Private/Language/Module/locallang_mod.xlf" datatype="plaintext" product-name="examples" date="2022-10-20T18:44:02+02:00">
 		<header/>
 		<body>
-            <trans-unit id="mlang_labels_tabdescr" resname="mlang_labels_tabdescr">
-				<source>Shows all TYPO3 Core PSR-14 Events</source>
-			</trans-unit>
-			<trans-unit id="mlang_labels_tablabel" resname="mlang_labels_tablabel">
-				<source>Event List</source>
-			</trans-unit>
-			<trans-unit id="mlang_tabs_tab" resname="mlang_tabs_tab">
-				<source>PSR14 Event List</source>
-			</trans-unit>
 			<trans-unit id="overview_title">
-                <source>Overview of Core PSR-14 Events in TYPO3</source>
+                <source>Overview of TYPO3 Core PSR-14 Events</source>
             </trans-unit>
 
             <trans-unit id="overview_intro">
@@ -23,18 +14,22 @@
             <trans-unit id="overview_details">
                 <source>This overview provides a complete list of all core events triggered in TYPO3, along with related information and documentation for each event. Each event is linked to the official TYPO3 documentation, so you can learn more about the event and how to use it.</source>
             </trans-unit>
-			<trans-unit id="show_events">
-                <source>to show the list switch the dropdown to the list view</source>
+
+            <trans-unit id="documentation_text">
+                <source>For an in-depth explanation of PSR-14 and the core events in TYPO3, you can visit the official overview of core events in the TYPO3 documentation. There you will find a detailed description of the various events and examples of how to work with them.</source>
             </trans-unit>
+
+            <trans-unit id="show_events">
+                <source>To show the list, switch the action menu dropdown to "List".</source>
+            </trans-unit>
+
             <trans-unit id="documentation_link">
                 <source>TYPO3 documentation</source>
             </trans-unit>
-			<trans-unit id="documentation_text">
-                <source>For an in-depth explanation of PSR-14 and the core events in TYPO3, you can visit the official overview of core events in the TYPO3 documentation. There you will find a detailed description of the various events and examples of how to work with them.</source>
+
+            <trans-unit id="loading_warning">
+                <source>Warning: First load of the list may take a while!</source>
             </trans-unit>
-			<trans-unit id="loading_warning">
-				<source>Warning the first load of the list may take a wile!</source>
-			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Templates/AdminModule/Index.html
+++ b/Resources/Private/Templates/AdminModule/Index.html
@@ -7,10 +7,12 @@
       
       <p>{translations.overview_details}</p>
       
-      <p>{translations.documentation_text} </p><b><a href="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Events/Events/Index.html"  target="_blank">{translations.documentation_link}</a></p></b>
+      <p>{translations.documentation_text} </p>
+
+      <p><strong><a href="https://docs.typo3.org/permalink/t3coreapi:eventlist" target="_blank">{translations.documentation_link}</a></strong></p>
 
       <div class="alert alert-warning">{translations.loading_warning}</div>
 
-      {translations.show_events}
+      <p>{translations.show_events}</p>
    </f:section>
 </html>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "cru/psr14-event-list",
-    "description": "Lists all Core psr 14 events",
+    "description": "Lists all Core PSR-14 events",
     "type": "typo3-cms-extension",
     "authors": [
         {
@@ -12,7 +12,7 @@
         "GPL-2.0-or-later"
     ],
     "require": {
-        "typo3/cms-core": "^12.4 || ^13.0"
+        "typo3/cms-core": "^12.4 || ^13.4 || 14.0.*@dev"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I've reworked the extension a bit to allow for a CLI symfony command to see the list, with several options.

Also I generally reworked that the documentation links are only fetched once (instead once per classname) and properly cached only once. This utlizes the objects.inv.json inventory for the documentation.

A fallback is added to support the specific currently used TYPO3 version for the doc links, and falling back to "main".

Also, a number of missing documentation links is emitted, might be helpful for documentation contributions.

Hope you find the contribution useful.