### PR TITLE
ci: update quality workflow to include TYPO3 14.3 support

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -36,13 +36,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - typo3: "12.4.*"
-            php: "8.1"
-          - typo3: "12.4.*"
-            php: "8.3"
           - typo3: "13.4.*"
             php: "8.2"
           - typo3: "13.4.*"
+            php: "8.4"
+          - typo3: "14.3.*"
+            php: "8.2"
+          - typo3: "14.3.*"
             php: "8.4"
 
     steps:


### PR DESCRIPTION
Add support for TYPO3 version 14.3 with PHP versions 8.2 and 8.4 in the CI matrix, ensuring compatibility with the latest TYPO3 releases.